### PR TITLE
QEP 323: Document code submission and merge policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ When the discussion and voting period ends, one of the following actions are tak
 - [#314 Code style and practice guidelines](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-314-coding-style.md). This
   QEP documents coding standards and conventions used throughout the QGIS code base. Developers are required to follow these standards
   when submitting code to QGIS.
+- [#323 Change submission and merge policies](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-323-code-submission-policy.md). This QEP documents policies for submission of changes to the main QGIS code repository.
+  Developers are required to follow these standards when submitting code to QGIS.
 - [#320 Backport policies](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-320-backport-policy.md). This
   QEP documents the standards and requirements for backporting changes from the ``master`` branch to Long Term Release (LTR)
   and current stable release branches in QGIS. Developers must follow these guidelines when submitting backports.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 QEP Process and workflow
 ---
 
-QEP's (QGIS Enhancement Proposals) are used in the process of creating and discussing new enhancements or policy for
+QEPs (QGIS Enhancement Proposals) are used in the process of creating and discussing new enhancements or policy for
 QGIS
 
-QEP's should generally be created for (only examples):
+QEPs should generally be created for (only examples):
 
 - Large application wide changes (e.g major UI redesign)
-- Large work with wider scope (e.g something that might effect how layers are loaded.)
+- Large work with wider scope (e.g something that might effect how layers are loaded)
 - Community processes and policies (e.g 3.0 release, changes to coding conventions)
 
 Generally smaller features do not require a QEP unless they can have large knock on effect.
 
 QEPs which describe project policies (such as those which describe coding conventions, acceptable practice for Pull
-Request reviews, etc) are mutable, and can be revised
-in future. See Processes and Policies section below for a description on how to amend an existing QEP.
+Request reviews, etc) are mutable, and can be revised in future. See Processes and Policies section below for a
+description on how to amend an existing QEP.
 
 ## Process and policies
 

--- a/qep-323-code-submission-policy.md
+++ b/qep-323-code-submission-policy.md
@@ -1,0 +1,47 @@
+# QGIS Enhancement 323: Change submission and merge policies
+
+## Summary
+
+This QEP documents policies for submission of changes to the main QGIS code repository.
+Developers are required to follow these standards when submitting code to QGIS.
+
+## Policies
+
+### 1. Change submission
+
+- 1.1. All changes must be submitted in the form of Pull Requests via GitHub
+  - 1.1.1 Direct push to master is permitted in **extreme circumstances** only. These are:
+    - String fixes for code comments or other non-functional text. (This does not include
+      code documentation, changes to the README files, or other documentation).
+    - Fixes for the CI environment or GitHub workflows where the lengthy run-time of
+      CI checks on pull requests is prohibitive, or where there is a need to repair
+      CI environment in order to allow normal pull request activity.
+    - Release and packaging related commits, such as version tagging.
+  - 1.1.2. All Pull Requests should be accompanied by a descriptive title and explanatory text.
+    Linking to existing issues, feature requests or external discussion are encouraged
+    for reviewer context. 
+- 1.2. All code submissions must be accompanied by appropriate unit tests.
+  - 1.2.1. All changes to the ``core``, ``analysis``, or ``server`` modules must
+    have extensive unit testing.
+    - 1.2.1.1. Exceptions are made where the effort required in mocking interfaces is excessive,
+      or where tests are likely to be flaky and trigger false-positives on the CI environment.
+  - 1.2.2. Changes to the ``gui`` or ``app`` modules should have as many tests as are possible
+    without extensive GUI interface mocking.
+    - 1.2.2.1. There are no expectations for testing of keyboard or mouse interaction with
+      dialogs and widgets.
+  - 1.2.3. Changes to data providers must be accompanied by appropriate unit tests, unless
+    the effort required to mock external interfaces is excessive.
+- 1.3. Code changes must abide by the [coding style policies](qep-314-coding-style.md).
+
+### 2. Pull Request Review and Merging
+
+Before a Pull Request can be merged to the repository, it must:
+
+- 2.1. Pass all existing CI checks.
+- 2.2. Be reviewed and approved by a Core Contributor with repository write permission.
+  - 2.2.1. Developers are not permitted to self-approve Pull Requests they have submitted.
+    - 2.2.1.1. An exception is made where a developer has submitted a "fixed up" version
+      of someone else's Pull Request, e.g. where the original submitter has not responded
+      to changes from the reviewer or where the original submitter has indicated that they
+      are otherwise unable to make the required changes themselves.
+- 2.3. Have no outstanding change requests or unresolved discussion from a Core Contributor.

--- a/qep-323-code-submission-policy.md
+++ b/qep-323-code-submission-policy.md
@@ -9,15 +9,18 @@ Developers are required to follow these standards when submitting code to QGIS.
 
 ### 1. Change submission
 
-- 1.1. All changes must be submitted in the form of Pull Requests via GitHub
-  - 1.1.1 Direct push to master is permitted in **extreme circumstances** only. These are:
+- 1.1. All changes must be submitted in the form of Pull Requests via GitHub.
+  - 1.1.1. Pull Requests can be made by **ANYONE**, and **EVERYONE** is encouraged to
+    contribute to QGIS coding! No special permission or status is required to submit
+    a change to QGIS.
+  - 1.1.2. Direct push to master is permitted in **extreme circumstances** only. These are:
     - String fixes for code comments or other non-functional text. (This does not include
       code documentation, changes to the README files, or other documentation).
     - Fixes for the CI environment or GitHub workflows where the lengthy run-time of
       CI checks on pull requests is prohibitive, or where there is a need to repair
       CI environment in order to allow normal pull request activity.
     - Release and packaging related commits, such as version tagging.
-  - 1.1.2. All Pull Requests should be accompanied by a descriptive title and explanatory text.
+  - 1.1.3. All Pull Requests should be accompanied by a descriptive title and explanatory text.
     Linking to existing issues, feature requests or external discussion are encouraged
     for reviewer context. 
 - 1.2. All code submissions must be accompanied by appropriate unit tests.
@@ -38,10 +41,13 @@ Developers are required to follow these standards when submitting code to QGIS.
 Before a Pull Request can be merged to the repository, it must:
 
 - 2.1. Pass all existing CI checks.
-- 2.2. Be reviewed and approved by a Core Contributor with repository write permission.
-  - 2.2.1. Developers are not permitted to self-approve Pull Requests they have submitted.
-    - 2.2.1.1. An exception is made where a developer has submitted a "fixed up" version
+- 2.2. Discussions and comments from any interested party are encouraged. No special
+  status or permissions are required to participate in the review discussion.
+- 2.3. Before merge, the Pull Request **MUST** be reviewed and approved by a **Core Contributor**
+  with repository write permission.
+  - 2.3.1. Developers are **NOT** permitted to self-approve Pull Requests they have submitted.
+    - 2.3.1.1. An exception is made where a developer has submitted a "fixed up" version
       of someone else's Pull Request, e.g. where the original submitter has not responded
       to changes from the reviewer or where the original submitter has indicated that they
       are otherwise unable to make the required changes themselves.
-- 2.3. Have no outstanding change requests or unresolved discussion from a Core Contributor.
+- 2.4. Have no outstanding change requests or unresolved discussion from a **Core Contributor**.

--- a/qep-323-code-submission-policy.md
+++ b/qep-323-code-submission-policy.md
@@ -20,6 +20,11 @@ Developers are required to follow these standards when submitting code to QGIS.
       CI checks on pull requests is prohibitive, or where there is a need to repair
       CI environment in order to allow normal pull request activity.
     - Release and packaging related commits, such as version tagging.
+    - In extremely rare cases, a significantly experienced QGIS developer may self-approve
+      their own PR in the situation that they are fixing a bug in their own code or when changes
+      are minor/trivial, and where they are absolutely sure there is no risk of danger or
+      regressions from the change, **if and only if** their original pull request had no
+      activity or discussion after at least one week. *This is discouraged, but permissible.*
   - 1.1.3. All Pull Requests should be accompanied by a descriptive title and explanatory text.
     Linking to existing issues, feature requests or external discussion are encouraged
     for reviewer context. 

--- a/qep-323-code-submission-policy.md
+++ b/qep-323-code-submission-policy.md
@@ -20,11 +20,6 @@ Developers are required to follow these standards when submitting code to QGIS.
       CI checks on pull requests is prohibitive, or where there is a need to repair
       CI environment in order to allow normal pull request activity.
     - Release and packaging related commits, such as version tagging.
-    - In extremely rare cases, a significantly experienced QGIS developer may self-approve
-      their own PR in the situation that they are fixing a bug in their own code or when changes
-      are minor/trivial, and where they are absolutely sure there is no risk of danger or
-      regressions from the change, **if and only if** their original pull request had no
-      activity or discussion after at least one week. *This is discouraged, but permissible.*
   - 1.1.3. All Pull Requests should be accompanied by a descriptive title and explanatory text.
     Linking to existing issues, feature requests or external discussion are encouraged
     for reviewer context. 
@@ -55,4 +50,9 @@ Before a Pull Request can be merged to the repository, it must:
       of someone else's Pull Request, e.g. where the original submitter has not responded
       to changes from the reviewer or where the original submitter has indicated that they
       are otherwise unable to make the required changes themselves.
+    - 2.3.1.2. In extremely rare cases, a significantly experienced QGIS developer may self-approve
+      their own PR in the situation that they are fixing a bug in their own code or when changes
+      are minor/trivial, and where they are absolutely sure there is no risk of danger or
+      regressions from the change, **if and only if** their original pull request had no
+      activity or discussion after at least one week. *This is discouraged, but permissible.*
 - 2.4. Have no outstanding change requests or unresolved discussion from a **Core Contributor**.


### PR DESCRIPTION
This QEP documents policies for submission of changes to the main QGIS code repository.

It is initially intended as a formal description of CURRENT PRACTICES ONLY, which can be later modified and revised (in an atomic manner) if we want to change any of these policies. As such, please refrain from using this initial request as a place to discuss changes to current practice. Rather, let's keep discussion focused on whether this is an accurate and complete description of our current submission practices. 👍

The end goal here is having a formal policy in place describing all our change submission rules, which will help ease new developers into contributing effectively to QGIS and remove some of the unspoken assumptions surrounding QGIS development.

Fixes https://github.com/qgis/QGIS-Enhancement-Proposals/issues/322