### PR TITLE
Require minimum 24 hour window for PR reviews

### DIFF
--- a/qep-323-code-submission-policy.md
+++ b/qep-323-code-submission-policy.md
@@ -56,3 +56,13 @@ Before a Pull Request can be merged to the repository, it must:
       regressions from the change, **if and only if** their original pull request had no
       activity or discussion after at least one week. *This is discouraged, but permissible.*
 - 2.4. Have no outstanding change requests or unresolved discussion from a **Core Contributor**.
+- 2.5. A Pull Request must remain open for at least 24 hours following submission, even if it has
+  already been approved (see 2.3). This is to allow wider feedback to be gathered prior to merge,
+  and to permit pre-merge feedback from developers in other time zones.
+  - Exceptions to this policy are:
+    - 2.5.1. Approved Pull Requests for backports to stable branches
+    - 2.5.2. "Emergency" pull requests, e.g. those which fix broken master builds, CI
+      infrastructure or which represent a time-sensitive security risk.
+    - 2.5.3. "Trivial" fixes. The definition of "trivial" is left open to common sense
+      and developer discretion, but is expected to include non-risky changes like
+      typo fixes, translation string fixes, tab order changes, or similar.


### PR DESCRIPTION
This proposal adds a new 24 hour minimum window for PR reviews to QEP 323.

This was originally proposed by @rouault in https://github.com/qgis/QGIS-Enhancement-Proposals/issues/303#issuecomment-2398064869, and is intended to allow wider feedback to be gathered prior to merges, and to permit pre-merge feedback from developers in other time zones.

Fixes https://github.com/qgis/QGIS-Enhancement-Proposals/issues/304


(If we decide to adopt this policy, we could possibly use the "minimum open time" GitHub action to enforce it. See https://github.com/gregsdennis/minimum-open-time. An example repo using this action is https://github.com/json-schema-org/json-schema-spec)