### PR TITLE
QEP 413: port TopoViewer to Browser

### DIFF
--- a/qep-413-postgis-topology-viewer-in-browser.md
+++ b/qep-413-postgis-topology-viewer-in-browser.md
@@ -1,0 +1,42 @@
+# QGIS Enhancement: Title
+
+**Date** 2026/01/06
+
+**Author** Sandro Santilli (@strk)
+
+**Contact** strk@kbt.io
+
+**Version** QGIS 4.X
+
+# Summary
+
+Port the DBManager TopoViewer plugin to the data browser
+
+## Motivation
+
+There have been a long standing will to remove the DBManager from core,
+and the TopoViewer plugin is one of the things that would be missing.
+
+## Proposed Solution
+
+Each PostGIS Topology schema shown in the data browser would get an additional
+item in the "Schema Operations" right-click menu: "TopoViewer".
+
+Clicking on the "TopoViewer" would load a tree of layers with the same
+structure of the one currently used by the DBManager TopoViewer plugin.
+
+### Affected Files
+
+TBD
+
+## Risks
+
+None anticipated
+
+## Performance Implications
+
+None anticipated
+
+## Further Considerations/Improvements
+
+In the future the templates could be made tweakable


### PR DESCRIPTION
This would be one more step toward demoting of DBManager ( https://lists.osgeo.org/pipermail/qgis-developer/2022-June/064850.html ).

The reason why this QEP does't yet have a number at this stage is reported in #350