### PR TITLE
QEP 410: Layer Name in GetFeatureInfo JSON Result as featureType

### DIFF
--- a/qep-410-json-layer-name.md
+++ b/qep-410-json-layer-name.md
@@ -1,0 +1,158 @@
+# QGIS Enhancement:  Layer Name in GetFeatureInfo JSON Result
+
+**Date** 2026/02/03
+
+**Author** Dave Signer (@signedav)
+
+**Contact** david at opengis dot ch
+
+**Version** QGIS 4.2
+
+# Summary
+
+When performing a `GetFeatureInfo` request, QGIS Server returns features for the requested position, layer, etc.
+
+While e.g. the XML format provides clear information about what layer the feature belongs to by passing the name (short-name), the **GeoJSON response lacks a reliable information to identify the layer name.**
+
+We are looking for a way to provide the layer information within the response without violating the [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946) standard and propose **enabling the passing of the layer name as a property.**
+
+# Current Behavior / Problem
+
+The response for `INFO_FORMAT=text/xml` explicitly wraps features in a `layer` element, providing the name (short-name):
+
+```xml
+<GetFeatureInfoResponse>
+<Layer name="whata.layer" title="What a Layer">
+<Feature id="1">
+<Attribute name="theid" value="1"/>
+<Attribute name="name" value="test"/>
+<Attribute name="oid" value="2"/>
+<Attribute name="somenumber" value="layer.1"/>
+</Feature>
+</Layer>
+</GetFeatureInfoResponse>
+```
+
+The response for `INFO_FORMAT=application/json` returns a flat `FeatureCollection`. The only hint regarding the source layer is usually concatenated within the `id` field:
+
+```json
+{
+  "features": [
+    {
+      "geometry": null,
+      "id": "whata.layer.1",
+      "properties": {
+        "name": "test",
+        "oid": 2,
+        "somenumber": "layer.1",
+        "theid": 1
+      },
+      "type": "Feature"
+    }
+  ],
+  "type": "FeatureCollection"
+}
+```
+
+QGIS Server generates the `id` by joining the layer name and the feature ID (usually the primary key) with a dot. In our case, this includes "whata.layer" (layer name) and "1" (our primary key column `theid`).
+
+While this provides some kind of information, a client cannot rely on it because both the layer name and the feature ID (primary key) can contain dots. This makes it impossible to parse the string accurately to determine where the layer name ends and the feature ID begins. And, since a client cannot know which property represents the primary key, it cannot simply cut it from the end of the `id` object.
+
+## Proposed Solution
+
+A [new QGIS Server extra parameter](https://docs.qgis.org/3.44/en/docs/server_manual/services/wms.html#getfeatureinfo) should be introduced: `WITH_LAYER_NAME_PROPERTY=layer_name`.
+
+```c++
+const QgsWmsParameter pWithLayerNameProperty( QgsWmsParameter::WITH_LAYER_NAME_PROPERTY, QMetaType::Type::QString );
+```
+
+The two get-methods check if the parameter was passed and, if so, what the desired property should be called:
+```c++
+QString withLayerNamePropertyAsString() const;
+bool withLayerNameProperty() const;
+```
+
+In [`QgsRenderer::convertFeatureInfoToJson`](https://github.com/qgis/QGIS/blob/master/src/server/services/wms/qgswmsrenderer.cpp#L2985), the option should be checked and, if true, another `extraProperty` should be added.
+
+Similar to the existing [`withDisplayName` property](https://github.com/qgis/QGIS/blob/master/src/server/services/wms/qgswmsrenderer.cpp#L3111-L3114) we would introduce the new functionality:
+
+```c++
+if ( mWmsParameters.withLayerNameProperty() )
+{
+  extraProperties.insert( mWmsParameters.withLayerNamePropertyAsString(), layerNickname(vl) );
+}
+```
+
+The result will then look like this:
+```json
+{
+  "features": [
+    {
+      "geometry": null,
+      "id": "whata.layer.1",
+      "properties": {
+        "name": "test",
+        "oid": 2,
+        "somenumber": "layer.1",
+        "theid": 1,
+        "layer_name": "whata.layer"
+      },
+      "type": "Feature"
+    }
+  ],
+  "type": "FeatureCollection"
+}
+```
+
+To ensure consistency, the new extra attribute should be included in the other formats as well as the JSON format. This part of the implementation will be located in [`QgsRenderer::featureInfoFromVectorLayer`](https://github.com/qgis/QGIS/blob/master/src/server/services/wms/qgswmsrenderer.cpp#L1845) and results in the following XML:
+
+```xml
+<GetFeatureInfoResponse>
+<Layer name="whata.layer" title="What a Layer">
+<Feature id="1">
+<Attribute name="theid" value="1"/>
+<Attribute name="name" value="test"/>
+<Attribute name="oid" value="2"/>
+<Attribute name="somenumber" value="layer.1"/>
+<Attribute name="layer_name" value="whata.layer"/>
+</Feature>
+</Layer>
+</GetFeatureInfoResponse>
+```
+
+### Name of the extra attribute
+
+The name of the extra property can be passed via the parameter. However, if the client passes `true`, `on`, `yes` or `1`, the default should align with the current `display_name`/`DisplayName` like this: `layer_name`/`LayerName`.
+
+### Name collition with feature attribute name
+
+This concerns only JSON, not XML etc. where multiple same-named values are allowed. To keep valid GeoJSON, we cannot return same-named properties. Therefore, in the event of a collision, the feature attribute is ignored and the extra property is prioritized. This aligns with the behavior of `WITH_DISPLAY_NAME` (there is still a [bug](https://github.com/qgis/QGIS/issues/65004) but it does not concern this QEP).
+
+### Why new WMS parameter instead of a servers side setting.
+
+The question is whether a QGIS-specific behavior should be triggered by [a QGIS Server extra parameter](https://docs.qgis.org/3.44/en/docs/server_manual/services/wms.html#getfeatureinfo) or a server-side setting. **We prefer the WMS parameter**. This is because some clients could require this information while others do not, yet they still request from the same server. Another reason is that, with this approach, existing clients that do not need this info will never encounter unasked information.
+
+## Deliverables
+
+- New WMS parameter and methods in `QgsWmsParameter`
+- Functionality in `QgsRenderer::featureInfoFromVectorLayer`
+- Functionality in `QgsRenderer::convertFeatureInfoToJson`
+
+### Affected Files
+
+- src/server/services/wms/qgswmsrenderer.h
+- src/server/services/wms/qgswmsrenderer.cpp
+- src/server/services/wms/qgswmsparameters.h
+- src/server/services/wms/qgswmsparameters.cpp
+
+## Risks
+
+The more QGIS-specific WMS parameters, the more complexity.
+
+## Performance Implications
+
+None expected.
+
+## Backwards Compatibility
+
+Completely ensured.

--- a/qep-410-json-layer-name.md
+++ b/qep-410-json-layer-name.md
@@ -58,7 +58,7 @@ QGIS Server generates the `id` by joining the layer name and the feature ID (usu
 
 While this provides some kind of information, a client cannot rely on it because both the layer name and the feature ID (primary key) can contain dots. This makes it impossible to parse the string accurately to determine where the layer name ends and the feature ID begins. And, since a client cannot know which property represents the primary key, it cannot simply cut it from the end of the `id` object.
 
-## Proposed Solution
+# Proposed Solution
 
 A [new QGIS Server extra parameter](https://docs.qgis.org/3.44/en/docs/server_manual/services/wms.html#getfeatureinfo) should be introduced: `WITH_LAYER_NAME_PROPERTY=layer_name`.
 
@@ -124,7 +124,7 @@ To ensure consistency, the new extra attribute should be included in the other f
 
 The name of the extra property can be passed via the parameter. However, if the client passes `true`, `on`, `yes` or `1`, the default should align with the current `display_name`/`DisplayName` like this: `layer_name`/`LayerName`.
 
-### Name collition with feature attribute name
+### Name collision with feature attribute name
 
 This concerns only JSON, not XML etc. where multiple same-named values are allowed. To keep valid GeoJSON, we cannot return same-named properties. Therefore, in the event of a collision, the feature attribute is ignored and the extra property is prioritized. This aligns with the behavior of `WITH_DISPLAY_NAME` (there is still a [bug](https://github.com/qgis/QGIS/issues/65004) but it does not concern this QEP).
 

--- a/qep-410-json-layer-name.md
+++ b/qep-410-json-layer-name.md
@@ -1,4 +1,4 @@
-# QGIS Enhancement:  Layer Name in GetFeatureInfo JSON Result
+# QGIS Enhancement:  Layer Name in GetFeatureInfo JSON Result as `featureType`
 
 **Date** 2026/02/03
 
@@ -8,15 +8,15 @@
 
 **Version** QGIS 4.2
 
-# Summary
+## Summary
 
 When performing a `GetFeatureInfo` request, QGIS Server returns features for the requested position, layer, etc.
 
 While e.g. the XML format provides clear information about what layer the feature belongs to by passing the name (short-name), the **GeoJSON response lacks a reliable information to identify the layer name.**
 
-We are looking for a way to provide the layer information within the response without violating the [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946) standard and propose **enabling the passing of the layer name as a property.**
+We are looking for a way to provide the layer information within the response without violating the [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946) standard and propose **enabling the passing of the layer name as a member called `featureType` as [defined in the OGC specification for JSON FG](https://portal.ogc.org/files/107269#feature-types).**
 
-# Current Behavior / Problem
+## Current Behavior / Problem
 
 The response for `INFO_FORMAT=text/xml` explicitly wraps features in a `layer` element, providing the name (short-name):
 
@@ -58,36 +58,18 @@ QGIS Server generates the `id` by joining the layer name and the feature ID (usu
 
 While this provides some kind of information, a client cannot rely on it because both the layer name and the feature ID (primary key) can contain dots. This makes it impossible to parse the string accurately to determine where the layer name ends and the feature ID begins. And, since a client cannot know which property represents the primary key, it cannot simply cut it from the end of the `id` object.
 
-# Proposed Solution
+## Proposed Solution
 
-A [new QGIS Server extra parameter](https://docs.qgis.org/3.44/en/docs/server_manual/services/wms.html#getfeatureinfo) should be introduced: `WITH_LAYER_NAME_PROPERTY=layer_name`.
+QGIS should return the layer name (short name) in the `featureType` member introduced in the ["OGC Features and Geometries JSON" (JSON-FG) specification](https://portal.ogc.org/files/107269). In GeoJSON, this additional member is permitted as a [foreign member](https://datatracker.ietf.org/doc/html/rfc7946#section-6.1).
 
-```c++
-const QgsWmsParameter pWithLayerNameProperty( QgsWmsParameter::WITH_LAYER_NAME_PROPERTY, QMetaType::Type::QString );
-```
-
-The two get-methods check if the parameter was passed and, if so, what the desired property should be called:
-```c++
-QString withLayerNamePropertyAsString() const;
-bool withLayerNameProperty() const;
-```
-
-In [`QgsRenderer::convertFeatureInfoToJson`](https://github.com/qgis/QGIS/blob/master/src/server/services/wms/qgswmsrenderer.cpp#L2985), the option should be checked and, if true, another `extraProperty` should be added.
-
-Similar to the existing [`withDisplayName` property](https://github.com/qgis/QGIS/blob/master/src/server/services/wms/qgswmsrenderer.cpp#L3111-L3114) we would introduce the new functionality:
-
-```c++
-if ( mWmsParameters.withLayerNameProperty() )
-{
-  extraProperties.insert( mWmsParameters.withLayerNamePropertyAsString(), layerNickname(vl) );
-}
-```
+A `featureType` can be returned for the entire `FeatureCollection` ([when it is the same for all features](https://portal.ogc.org/files/107269#types-schemas_feature-type)) or per `feature`. Since QGIS returns a "flat" `FeatureCollection` for all the requested features of the requested layers, we suggest returning it per `feature`.
 
 The result will then look like this:
 ```json
 {
   "features": [
     {
+      "featureType": "whata.layer",
       "geometry": null,
       "id": "whata.layer.1",
       "properties": {
@@ -104,50 +86,32 @@ The result will then look like this:
 }
 ```
 
-To ensure consistency, the new extra attribute should be included in the other formats as well as the JSON format. This part of the implementation will be located in [`QgsRenderer::featureInfoFromVectorLayer`](https://github.com/qgis/QGIS/blob/master/src/server/services/wms/qgswmsrenderer.cpp#L1845) and results in the following XML:
+We suggest returning the `featureType` member containing the layer name in any case. We do not see value in introducing a new setting or WMS parameter.
 
-```xml
-<GetFeatureInfoResponse>
-<Layer name="whata.layer" title="What a Layer">
-<Feature id="1">
-<Attribute name="theid" value="1"/>
-<Attribute name="name" value="test"/>
-<Attribute name="oid" value="2"/>
-<Attribute name="somenumber" value="layer.1"/>
-<Attribute name="layer_name" value="whata.layer"/>
-</Feature>
-</Layer>
-</GetFeatureInfoResponse>
+## Implementation
+
+In [`QgsRenderer::convertFeatureInfoToJson`](https://github.com/qgis/QGIS/blob/master/src/server/services/wms/qgswmsrenderer.cpp#L3115) the layer name should be passed to [`QgsJsonExporter::exportFeatureToJsonObject`](https://github.com/qgis/QGIS/blob/master/src/core/qgsjsonutils.h#L241):
+
+```c++
+  json["features"].push_back( exporter.exportFeatureToJsonObject( feature, extraProperties, id, layerName ) );
 ```
 
-### Name of the extra attribute
+Where it can be appended to the member `featureType`.
 
-The name of the extra property can be passed via the parameter. However, if the client passes `true`, `on`, `yes` or `1`, the default should align with the current `display_name`/`DisplayName` like this: `layer_name`/`LayerName`.
+### Deliverables
 
-### Name collision with feature attribute name
-
-This concerns only JSON, not XML etc. where multiple same-named values are allowed. To keep valid GeoJSON, we cannot return same-named properties. Therefore, in the event of a collision, the feature attribute is ignored and the extra property is prioritized. This aligns with the behavior of `WITH_DISPLAY_NAME` (there is still a [bug](https://github.com/qgis/QGIS/issues/65004) but it does not concern this QEP).
-
-### Why new WMS parameter instead of a servers side setting.
-
-The question is whether a QGIS-specific behavior should be triggered by [a QGIS Server extra parameter](https://docs.qgis.org/3.44/en/docs/server_manual/services/wms.html#getfeatureinfo) or a server-side setting. **We prefer the WMS parameter**. This is because some clients could require this information while others do not, yet they still request from the same server. Another reason is that, with this approach, existing clients that do not need this info will never encounter unasked information.
-
-## Deliverables
-
-- New WMS parameter and methods in `QgsWmsParameter`
-- Functionality in `QgsRenderer::featureInfoFromVectorLayer`
 - Functionality in `QgsRenderer::convertFeatureInfoToJson`
+- Functionality in `QgsJsonExporter::exportFeatureToJsonObject`
 
 ### Affected Files
 
-- src/server/services/wms/qgswmsrenderer.h
 - src/server/services/wms/qgswmsrenderer.cpp
-- src/server/services/wms/qgswmsparameters.h
-- src/server/services/wms/qgswmsparameters.cpp
+- src/core/qgsjsonutils.h
+- src/core/qgsjsonutils.cpp
 
 ## Risks
 
-The more QGIS-specific WMS parameters, the more complexity.
+None expected.
 
 ## Performance Implications
 
@@ -155,4 +119,4 @@ None expected.
 
 ## Backwards Compatibility
 
-Completely ensured.
+Ensured.


### PR DESCRIPTION
This QEP introduces the missing information to identify the layer name when receiving features in GeoJSON via `GetFeatureInfo` by returning the layer name as the JSON-FG member `featureType`. 

See details in the description [here](https://github.com/signedav/QGIS-Enhancement-Proposals/blob/json-layername/qep-410-json-layer-name.md).