### PR TITLE
[CodingStyle] Precise member prefix scope

### DIFF
--- a/qep-314-coding-style.md
+++ b/qep-314-coding-style.md
@@ -17,7 +17,7 @@ Notes:
 
   - 1.1.1. Local variables should have no name prefix (eg do not prefix variable names with ``my``)
   - 1.1.2. [Hungarian notation](https://en.m.wikipedia.org/wiki/Hungarian_notation) is NOT used, except in some exceptional circumstances (eg variable names used with the gdal c API)
-  - 1.1.3. Private and protected member variables should have a ``m`` prefix (eg ``mLineWidth``)
+  - 1.1.3. Private and protected member variables should have a ``m`` prefix (eg ``mLineWidth``). Public member variables should use camel case, without any prefix (eg ``lineWidth``).
   - 1.1.4. Static variables should have a ``s`` prefix (eg ``sMutex``)
   - 1.1.5. constexpr or static constants should be named in all uppercase, with underscore separators (eg ``DEFAULT_LINE_WIDTH``)
 - 1.2. Classes should be named with a ``Qgs`` prefix, eg ``QgsGeometry``

--- a/qep-314-coding-style.md
+++ b/qep-314-coding-style.md
@@ -17,7 +17,7 @@ Notes:
 
   - 1.1.1. Local variables should have no name prefix (eg do not prefix variable names with ``my``)
   - 1.1.2. [Hungarian notation](https://en.m.wikipedia.org/wiki/Hungarian_notation) is NOT used, except in some exceptional circumstances (eg variable names used with the gdal c API)
-  - 1.1.3. Member variables should have a ``m`` prefix (eg ``mLineWidth``)
+  - 1.1.3. Private and protected member variables should have a ``m`` prefix (eg ``mLineWidth``)
   - 1.1.4. Static variables should have a ``s`` prefix (eg ``sMutex``)
   - 1.1.5. constexpr or static constants should be named in all uppercase, with underscore separators (eg ``DEFAULT_LINE_WIDTH``)
 - 1.2. Classes should be named with a ``Qgs`` prefix, eg ``QgsGeometry``


### PR DESCRIPTION
It applies only to private and protected.

Related to this [comment](https://github.com/qgis/QGIS/pull/66197#issuecomment-4550528015)