### PR TITLE
Add Exceptional Breakage clause to stable API policy

### DIFF
--- a/qep-425-stable-api.md
+++ b/qep-425-stable-api.md
@@ -61,7 +61,7 @@ in QGIS 4.6, 4.10, and later 4.x releases.
       poses a severe security risk, introduces an insurmountable maintenance burden, or fundamentally
       blocks critical bug fixes.
     - 1.4.4.2 Any such breaking change must be heavily justified, proposed publicly, and explicitly
-      approved by a QGIS Enhancement Policy prior to implementation.
+      approved by a QGIS Enhancement Proposal prior to implementation.
     - 1.4.4.3 Where possible, an accelerated deprecation warning should be provided to users
       for at least one minor release before the breakage occurs.
 

--- a/qep-425-stable-api.md
+++ b/qep-425-stable-api.md
@@ -52,7 +52,7 @@ in QGIS 4.6, 4.10, and later 4.x releases.
       to suppress the deprecation build warnings, **ONLY** for code in methods or classes which
       themselves are deprecated. (I.e. where the code calling the deprecated API will be removed at
       the same time as the deprecated API itself).
-  - 1.4.3 Generally, breakage of the deprecated method is NOT permitted until a suitable major. The
+  - 1.4.3 Generally, breakage of the deprecated method is NOT permitted until a suitable major release. The
     developer marking a method as deprecated must take care that they do not break any plugins
     or scripts which still use the deprecated API.
   - 1.4.4 Exceptional Breakage: In rare, extreme circumstances, backwards-incompatible API changes

--- a/qep-425-stable-api.md
+++ b/qep-425-stable-api.md
@@ -52,9 +52,18 @@ in QGIS 4.6, 4.10, and later 4.x releases.
       to suppress the deprecation build warnings, **ONLY** for code in methods or classes which
       themselves are deprecated. (I.e. where the code calling the deprecated API will be removed at
       the same time as the deprecated API itself).
-  - 1.4.3 Breakage of the deprecated method is **NOT** permitted until a suitable major release. The 
+  - 1.4.3 Generally, breakage of the deprecated method is NOT permitted until a suitable major. The
     developer marking a method as deprecated must take care that they do not break any plugins
     or scripts which still use the deprecated API.
+  - 1.4.4 Exceptional Breakage: In rare, extreme circumstances, backwards-incompatible API changes
+    may be permitted prior to a new major release.
+    - 1.4.4.1 This exemption is strictly limited to cases where maintaining backward compatibility
+      poses a severe security risk, introduces an insurmountable maintenance burden, or fundamentally
+      blocks critical bug fixes.
+    - 1.4.4.2 Any such breaking change must be heavily justified, proposed publicly, and explicitly
+      approved by a QGIS Enhancement Policy prior to implementation.
+    - 1.4.4.3 Where possible, an accelerated deprecation warning should be provided to users
+      for at least one minor release before the breakage occurs.
 
 ## 2.0 Stable Document Format Policy
 


### PR DESCRIPTION
This adds a mechanism for API breakage in exceptional cases. 

## Justification

In theory the stable API policy means that a plugin or script written in QGIS 3.0 will continue to work without issues or maintenance in QGIS 3.44. This is a noble goal, but one which is not grounded in reality. Despite us sticking religiously to this policy throughout the 3.x development cycle, a plugin written for QGIS 3.0 will (in many cases) require modifications to function under 3.44. The root cause of this is that a QGIS plugin is NOT just dependant on the PyQGIS API, but also is dependent on many third party libraries and tools (eg Python itself, PyQt, GDAL, PROJ, ...), which do NOT have the same release cycle or stability guarantees that QGIS holds.

Some concrete examples of the types of breakage which occurred throughout the 3.x cycle:

- Python 3.10 introduced a change where builtin and extension functions that take integer arguments no longer accepted float values. (Previously these were automatically truncated to integers). With Python 3.10, an explicit TypeError exception is raised when a float value is passed to these functions. (see https://docs.python.org/3.10/whatsnew/changelog.html bpo-37999). This directly affected many QGIS plugins, as previously it was possible (and commonplace) to do something like: `list_view.setColumnCount( widget.width() / 200 )`. This had to be updated to explicitly cast to int `list_view.setColumnCount( int(widget.width() / 200 ) )`.
- While the Qt Webkit library (and associated PyQt library) was widely available in all operating systems that offered QGIS 3.0, this library was deprecated and saw decreasing availability through to 3.44. Now, the library is only available on a minority of platforms. This caused significant disruption for any plugin which relied on this library to show HTML content.
- GDAL 3/PROJ 6 transition: This occurred in the middle of the QGIS 3.x cycle. Any plugin which directly utilised the gdal python bindings was impacted, and needed to add compatibility code for the new release. Additionally, PROJ 6 was a major change (moving away from the widely used proj string representation of CRSes) which also required updates from plugin authors to handle.

The stable API policy has been an unbreakable constraint for QGIS development. We currently have no (policy-compliant) way to break API, even when that API is blocking bug fixes, introducing security risks, or becomes a mammoth maintenance burden for QGIS developers.

This change proposes that we allow API breakage in **EXCEPTIONAL CIRCUMSTANCES**. It provides security for downstream PyQGIS developers, while also granting upstream QGIS developers the freedom to make necessary changes when those changes do break API.

As an example of the type of API breakage this would permit, my initial desire is to use it to remove the pure Python Processing widget wrapper API. This API was deprecated early in QGIS 3, and has become an massive roadblock in Processing development. It is the direct cause of many high impact bugs in Processing and the model designer, which CANNOT be fixed while we have to support the deprecated API. It has slowed Processing development, bloated the code base, and forces users into a degraded experience. By removing this API we would be able to move all the Processing GUI and model designer logic to pure c+, and completely avoid bugs which cause crashes due to duelling Python/c++ object ownership.

## Downstream PyQGIS developer reassurance

The changes proposed here are for exceptional circumstances only, and there are safeguards in place to prevent this policy being abused. Before breaking API, a specific QEP for that breakage **must** be submitted and accepted. This prevents breakage without wide discussion about the ramifications, and gives downstream developers a channel to push back against proposed breakage when they feel it is unjustified.


